### PR TITLE
Fix use newer nox

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ namespace packages.
 To run the scenarios:
 
 ```
-$ pip install --upgrade setuptools virtualenv nox-automation
+$ pip install --upgrade setuptools virtualenv nox
 $ nox --report report.json
 ```
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 import os
-
 import nox
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+# -- REQUIRES: nox >= 2018.10.17
+# SEE: https://nox.readthedocs.io/en/stable/index.html
+USE_PYTHON_VERSIONS_DEFAULT = ["2.7", "3.7"]
+USE_PYTHON_VERSIONS = os.environ.get("NOXFILE_PYTHON_VERSIONS", "").split()
+if not USE_PYTHON_VERSIONS:
+    USE_PYTHON_VERSIONS = USE_PYTHON_VERSIONS_DEFAULT
+
 
 install_commands = (
     ('pip', 'install', '.'),
@@ -36,11 +43,10 @@ def install_packages(session, package_a, package_b, command_a, command_b):
     session.chdir(HERE)
 
 
-@nox.parametrize('interpreter', ('python2', 'python3'))
+@nox.session(python=USE_PYTHON_VERSIONS)
 @nox.parametrize('command_a', install_commands)
 @nox.parametrize('command_b', install_commands)
-def session_pkgutil(session, interpreter, command_a, command_b):
-    session.interpreter = interpreter
+def session_pkgutil(session, command_a, command_b):
     session.install('--upgrade', 'setuptools', 'pip')
     install_packages(
         session, 'pkgutil/pkg_a', 'pkgutil/pkg_b',
@@ -48,11 +54,10 @@ def session_pkgutil(session, interpreter, command_a, command_b):
     session.run('python', 'verify_packages.py')
 
 
-@nox.parametrize('interpreter', ('python2', 'python3'))
+@nox.session(python=USE_PYTHON_VERSIONS)
 @nox.parametrize('command_a', install_commands)
 @nox.parametrize('command_b', install_commands)
-def session_pkg_resources(session, interpreter, command_a, command_b):
-    session.interpreter = interpreter
+def session_pkg_resources(session, command_a, command_b):
     session.install('--upgrade', 'setuptools', 'pip')
     install_packages(
         session, 'pkg_resources/pkg_a', 'pkg_resources/pkg_b',
@@ -60,11 +65,10 @@ def session_pkg_resources(session, interpreter, command_a, command_b):
     session.run('python', 'verify_packages.py')
 
 
-@nox.parametrize('interpreter', ('python2', 'python3'))
+@nox.session(python=USE_PYTHON_VERSIONS)
 @nox.parametrize('command_a', install_commands)
 @nox.parametrize('command_b', install_commands)
-def session_pep420(session, interpreter, command_a, command_b):
-    session.interpreter = interpreter
+def session_pep420(session, command_a, command_b):
     session.install('--upgrade', 'setuptools', 'pip')
     install_packages(
         session, 'native/pkg_a', 'native/pkg_b',
@@ -72,12 +76,11 @@ def session_pep420(session, interpreter, command_a, command_b):
     session.run('python', 'verify_packages.py')
 
 
-@nox.parametrize('interpreter', ('python2', 'python3'))
+@nox.session(python=USE_PYTHON_VERSIONS)
 @nox.parametrize('command_a', install_commands)
 @nox.parametrize('command_b', install_commands)
 def session_cross_pkg_resources_pkgutil(
-        session, interpreter, command_a, command_b):
-    session.interpreter = interpreter
+        session, command_a, command_b):
     session.install('--upgrade', 'setuptools', 'pip')
     install_packages(
         session, 'pkg_resources/pkg_a', 'pkgutil/pkg_b',
@@ -85,12 +88,11 @@ def session_cross_pkg_resources_pkgutil(
     session.run('python', 'verify_packages.py')
 
 
-@nox.parametrize('interpreter', ('python2', 'python3'))
+@nox.session(python=USE_PYTHON_VERSIONS)
 @nox.parametrize('command_a', install_commands)
 @nox.parametrize('command_b', install_commands)
 def session_cross_pep420_pkgutil(
-        session, interpreter, command_a, command_b):
-    session.interpreter = interpreter
+        session, command_a, command_b):
     session.install('--upgrade', 'setuptools', 'pip')
     install_packages(
         session, 'native/pkg_a', 'pkgutil/pkg_b',

--- a/report_to_table.py
+++ b/report_to_table.py
@@ -12,9 +12,14 @@ with io.open('table.md', 'w') as f:
     f.write(u'| Type | Interpreter | Package A command | Package B command | Status |\n')
     f.write(u'| --- | --- | --- | --- | --- |\n')
     for session in data['sessions']:
+        session_name = session['name']
+        session_detailled_name = session['signatures'][-1]
+        session_interpreter = session_detailled_name.replace(session_name + "-", "python")
+        session_name = session_name.replace("session_", "")
+
         f.write(u'| {} | {} | {} | {} | {} |\n'.format(
-            session['name'],
-            session['args']['interpreter'],
+            session_name,
+            session_interpreter,
             ' '.join(session['args']['command_a']),
             ' '.join(session['args']['command_b']),
             u'✅' if session['result_code'] else u'❌'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# -- PYTHON PACKAGE REQUIREMENTS:
+# USE: pip install -r <THIS_FILE>
+
+setuptools 
+virtualenv
+nox >= 2018.10.17

--- a/table.md
+++ b/table.md
@@ -1,169 +1,162 @@
-| Tool | Version(s) |
-| --- | --- |
-| python | 2.7.15, 3.6.5 |
-| setuptools | 39.1.0 |
-| pip | 10.0.1 |
-| wheel | 0.31.0 |
-
 | Type | Interpreter | Package A command | Package B command | Status |
 | --- | --- | --- | --- | --- |
-| cross_pep420_pkgutil | python2 | pip install . | pip install . | ✅ |
-| cross_pep420_pkgutil | python2 | pip install . | pip install -e . | ❌ |
-| cross_pep420_pkgutil | python2 | pip install . | python setup.py install | ❌ |
-| cross_pep420_pkgutil | python2 | pip install . | python setup.py develop | ❌ |
-| cross_pep420_pkgutil | python2 | pip install -e . | pip install . | ❌ |
-| cross_pep420_pkgutil | python2 | pip install -e . | pip install -e . | ❌ |
-| cross_pep420_pkgutil | python2 | pip install -e . | python setup.py install | ❌ |
-| cross_pep420_pkgutil | python2 | pip install -e . | python setup.py develop | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py install | pip install . | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py install | pip install -e . | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py install | python setup.py install | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py install | python setup.py develop | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py develop | pip install . | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py develop | pip install -e . | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py develop | python setup.py install | ❌ |
-| cross_pep420_pkgutil | python2 | python setup.py develop | python setup.py develop | ❌ |
-| cross_pep420_pkgutil | python3 | pip install . | pip install . | ✅ |
-| cross_pep420_pkgutil | python3 | pip install . | pip install -e . | ✅ |
-| cross_pep420_pkgutil | python3 | pip install . | python setup.py install | ✅ |
-| cross_pep420_pkgutil | python3 | pip install . | python setup.py develop | ✅ |
-| cross_pep420_pkgutil | python3 | pip install -e . | pip install . | ✅ |
-| cross_pep420_pkgutil | python3 | pip install -e . | pip install -e . | ✅ |
-| cross_pep420_pkgutil | python3 | pip install -e . | python setup.py install | ✅ |
-| cross_pep420_pkgutil | python3 | pip install -e . | python setup.py develop | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py install | pip install . | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py install | pip install -e . | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py install | python setup.py install | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py install | python setup.py develop | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py develop | pip install . | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py develop | pip install -e . | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py develop | python setup.py install | ✅ |
-| cross_pep420_pkgutil | python3 | python setup.py develop | python setup.py develop | ✅ |
-| cross_pkg_resources_pkgutil | python2 | pip install . | pip install . | ✅ |
-| cross_pkg_resources_pkgutil | python2 | pip install . | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install . | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install . | python setup.py develop | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install -e . | pip install . | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install -e . | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install -e . | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python2 | pip install -e . | python setup.py develop | ❌ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py install | pip install . | ✅ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py install | pip install -e . | ✅ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py install | python setup.py install | ✅ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py install | python setup.py develop | ✅ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py develop | pip install . | ❌ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py develop | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py develop | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python2 | python setup.py develop | python setup.py develop | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install . | pip install . | ✅ |
-| cross_pkg_resources_pkgutil | python3 | pip install . | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install . | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install . | python setup.py develop | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install -e . | pip install . | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install -e . | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install -e . | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python3 | pip install -e . | python setup.py develop | ❌ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py install | pip install . | ✅ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py install | pip install -e . | ✅ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py install | python setup.py install | ✅ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py install | python setup.py develop | ✅ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py develop | pip install . | ❌ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py develop | pip install -e . | ❌ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py develop | python setup.py install | ❌ |
-| cross_pkg_resources_pkgutil | python3 | python setup.py develop | python setup.py develop | ❌ |
-| pep420 | python2 | pip install . | pip install . | ❌ |
-| pep420 | python2 | pip install . | pip install -e . | ❌ |
-| pep420 | python2 | pip install . | python setup.py install | ❌ |
-| pep420 | python2 | pip install . | python setup.py develop | ❌ |
-| pep420 | python2 | pip install -e . | pip install . | ❌ |
-| pep420 | python2 | pip install -e . | pip install -e . | ❌ |
-| pep420 | python2 | pip install -e . | python setup.py install | ❌ |
-| pep420 | python2 | pip install -e . | python setup.py develop | ❌ |
-| pep420 | python2 | python setup.py install | pip install . | ❌ |
-| pep420 | python2 | python setup.py install | pip install -e . | ❌ |
-| pep420 | python2 | python setup.py install | python setup.py install | ❌ |
-| pep420 | python2 | python setup.py install | python setup.py develop | ❌ |
-| pep420 | python2 | python setup.py develop | pip install . | ❌ |
-| pep420 | python2 | python setup.py develop | pip install -e . | ❌ |
-| pep420 | python2 | python setup.py develop | python setup.py install | ❌ |
-| pep420 | python2 | python setup.py develop | python setup.py develop | ❌ |
-| pep420 | python3 | pip install . | pip install . | ✅ |
-| pep420 | python3 | pip install . | pip install -e . | ✅ |
-| pep420 | python3 | pip install . | python setup.py install | ✅ |
-| pep420 | python3 | pip install . | python setup.py develop | ✅ |
-| pep420 | python3 | pip install -e . | pip install . | ✅ |
-| pep420 | python3 | pip install -e . | pip install -e . | ✅ |
-| pep420 | python3 | pip install -e . | python setup.py install | ✅ |
-| pep420 | python3 | pip install -e . | python setup.py develop | ✅ |
-| pep420 | python3 | python setup.py install | pip install . | ✅ |
-| pep420 | python3 | python setup.py install | pip install -e . | ✅ |
-| pep420 | python3 | python setup.py install | python setup.py install | ✅ |
-| pep420 | python3 | python setup.py install | python setup.py develop | ✅ |
-| pep420 | python3 | python setup.py develop | pip install . | ✅ |
-| pep420 | python3 | python setup.py develop | pip install -e . | ✅ |
-| pep420 | python3 | python setup.py develop | python setup.py install | ✅ |
-| pep420 | python3 | python setup.py develop | python setup.py develop | ✅ |
-| pkg_resources | python2 | pip install . | pip install . | ✅ |
-| pkg_resources | python2 | pip install . | pip install -e . | ✅ |
-| pkg_resources | python2 | pip install . | python setup.py install | ❌ |
-| pkg_resources | python2 | pip install . | python setup.py develop | ✅ |
-| pkg_resources | python2 | pip install -e . | pip install . | ✅ |
-| pkg_resources | python2 | pip install -e . | pip install -e . | ✅ |
-| pkg_resources | python2 | pip install -e . | python setup.py install | ❌ |
-| pkg_resources | python2 | pip install -e . | python setup.py develop | ✅ |
-| pkg_resources | python2 | python setup.py install | pip install . | ❌ |
-| pkg_resources | python2 | python setup.py install | pip install -e . | ❌ |
-| pkg_resources | python2 | python setup.py install | python setup.py install | ✅ |
-| pkg_resources | python2 | python setup.py install | python setup.py develop | ❌ |
-| pkg_resources | python2 | python setup.py develop | pip install . | ✅ |
-| pkg_resources | python2 | python setup.py develop | pip install -e . | ✅ |
-| pkg_resources | python2 | python setup.py develop | python setup.py install | ❌ |
-| pkg_resources | python2 | python setup.py develop | python setup.py develop | ✅ |
-| pkg_resources | python3 | pip install . | pip install . | ✅ |
-| pkg_resources | python3 | pip install . | pip install -e . | ✅ |
-| pkg_resources | python3 | pip install . | python setup.py install | ❌ |
-| pkg_resources | python3 | pip install . | python setup.py develop | ✅ |
-| pkg_resources | python3 | pip install -e . | pip install . | ✅ |
-| pkg_resources | python3 | pip install -e . | pip install -e . | ✅ |
-| pkg_resources | python3 | pip install -e . | python setup.py install | ❌ |
-| pkg_resources | python3 | pip install -e . | python setup.py develop | ✅ |
-| pkg_resources | python3 | python setup.py install | pip install . | ❌ |
-| pkg_resources | python3 | python setup.py install | pip install -e . | ❌ |
-| pkg_resources | python3 | python setup.py install | python setup.py install | ✅ |
-| pkg_resources | python3 | python setup.py install | python setup.py develop | ❌ |
-| pkg_resources | python3 | python setup.py develop | pip install . | ✅ |
-| pkg_resources | python3 | python setup.py develop | pip install -e . | ✅ |
-| pkg_resources | python3 | python setup.py develop | python setup.py install | ❌ |
-| pkg_resources | python3 | python setup.py develop | python setup.py develop | ✅ |
-| pkgutil | python2 | pip install . | pip install . | ✅ |
-| pkgutil | python2 | pip install . | pip install -e . | ✅ |
-| pkgutil | python2 | pip install . | python setup.py install | ✅ |
-| pkgutil | python2 | pip install . | python setup.py develop | ✅ |
-| pkgutil | python2 | pip install -e . | pip install . | ✅ |
-| pkgutil | python2 | pip install -e . | pip install -e . | ✅ |
-| pkgutil | python2 | pip install -e . | python setup.py install | ✅ |
-| pkgutil | python2 | pip install -e . | python setup.py develop | ✅ |
-| pkgutil | python2 | python setup.py install | pip install . | ✅ |
-| pkgutil | python2 | python setup.py install | pip install -e . | ✅ |
-| pkgutil | python2 | python setup.py install | python setup.py install | ✅ |
-| pkgutil | python2 | python setup.py install | python setup.py develop | ✅ |
-| pkgutil | python2 | python setup.py develop | pip install . | ✅ |
-| pkgutil | python2 | python setup.py develop | pip install -e . | ✅ |
-| pkgutil | python2 | python setup.py develop | python setup.py install | ✅ |
-| pkgutil | python2 | python setup.py develop | python setup.py develop | ✅ |
-| pkgutil | python3 | pip install . | pip install . | ✅ |
-| pkgutil | python3 | pip install . | pip install -e . | ✅ |
-| pkgutil | python3 | pip install . | python setup.py install | ✅ |
-| pkgutil | python3 | pip install . | python setup.py develop | ✅ |
-| pkgutil | python3 | pip install -e . | pip install . | ✅ |
-| pkgutil | python3 | pip install -e . | pip install -e . | ✅ |
-| pkgutil | python3 | pip install -e . | python setup.py install | ✅ |
-| pkgutil | python3 | pip install -e . | python setup.py develop | ✅ |
-| pkgutil | python3 | python setup.py install | pip install . | ✅ |
-| pkgutil | python3 | python setup.py install | pip install -e . | ✅ |
-| pkgutil | python3 | python setup.py install | python setup.py install | ✅ |
-| pkgutil | python3 | python setup.py install | python setup.py develop | ✅ |
-| pkgutil | python3 | python setup.py develop | pip install . | ✅ |
-| pkgutil | python3 | python setup.py develop | pip install -e . | ✅ |
-| pkgutil | python3 | python setup.py develop | python setup.py install | ✅ |
-| pkgutil | python3 | python setup.py develop | python setup.py develop | ✅ |
+| pkgutil | python2.7 | pip install . | pip install . | ✅ |
+| pkgutil | python2.7 | pip install . | pip install -e . | ✅ |
+| pkgutil | python2.7 | pip install . | python setup.py install | ✅ |
+| pkgutil | python2.7 | pip install . | python setup.py develop | ✅ |
+| pkgutil | python2.7 | pip install -e . | pip install . | ✅ |
+| pkgutil | python2.7 | pip install -e . | pip install -e . | ✅ |
+| pkgutil | python2.7 | pip install -e . | python setup.py install | ✅ |
+| pkgutil | python2.7 | pip install -e . | python setup.py develop | ✅ |
+| pkgutil | python2.7 | python setup.py install | pip install . | ✅ |
+| pkgutil | python2.7 | python setup.py install | pip install -e . | ✅ |
+| pkgutil | python2.7 | python setup.py install | python setup.py install | ✅ |
+| pkgutil | python2.7 | python setup.py install | python setup.py develop | ✅ |
+| pkgutil | python2.7 | python setup.py develop | pip install . | ✅ |
+| pkgutil | python2.7 | python setup.py develop | pip install -e . | ✅ |
+| pkgutil | python2.7 | python setup.py develop | python setup.py install | ✅ |
+| pkgutil | python2.7 | python setup.py develop | python setup.py develop | ✅ |
+| pkgutil | python3.7 | pip install . | pip install . | ✅ |
+| pkgutil | python3.7 | pip install . | pip install -e . | ✅ |
+| pkgutil | python3.7 | pip install . | python setup.py install | ✅ |
+| pkgutil | python3.7 | pip install . | python setup.py develop | ✅ |
+| pkgutil | python3.7 | pip install -e . | pip install . | ✅ |
+| pkgutil | python3.7 | pip install -e . | pip install -e . | ✅ |
+| pkgutil | python3.7 | pip install -e . | python setup.py install | ✅ |
+| pkgutil | python3.7 | pip install -e . | python setup.py develop | ✅ |
+| pkgutil | python3.7 | python setup.py install | pip install . | ✅ |
+| pkgutil | python3.7 | python setup.py install | pip install -e . | ✅ |
+| pkgutil | python3.7 | python setup.py install | python setup.py install | ✅ |
+| pkgutil | python3.7 | python setup.py install | python setup.py develop | ✅ |
+| pkgutil | python3.7 | python setup.py develop | pip install . | ✅ |
+| pkgutil | python3.7 | python setup.py develop | pip install -e . | ✅ |
+| pkgutil | python3.7 | python setup.py develop | python setup.py install | ✅ |
+| pkgutil | python3.7 | python setup.py develop | python setup.py develop | ✅ |
+| pkg_resources | python2.7 | pip install . | pip install . | ✅ |
+| pkg_resources | python2.7 | pip install . | pip install -e . | ✅ |
+| pkg_resources | python2.7 | pip install . | python setup.py install | ❌ |
+| pkg_resources | python2.7 | pip install . | python setup.py develop | ✅ |
+| pkg_resources | python2.7 | pip install -e . | pip install . | ✅ |
+| pkg_resources | python2.7 | pip install -e . | pip install -e . | ✅ |
+| pkg_resources | python2.7 | pip install -e . | python setup.py install | ❌ |
+| pkg_resources | python2.7 | pip install -e . | python setup.py develop | ✅ |
+| pkg_resources | python2.7 | python setup.py install | pip install . | ❌ |
+| pkg_resources | python2.7 | python setup.py install | pip install -e . | ❌ |
+| pkg_resources | python2.7 | python setup.py install | python setup.py install | ✅ |
+| pkg_resources | python2.7 | python setup.py install | python setup.py develop | ❌ |
+| pkg_resources | python2.7 | python setup.py develop | pip install . | ✅ |
+| pkg_resources | python2.7 | python setup.py develop | pip install -e . | ✅ |
+| pkg_resources | python2.7 | python setup.py develop | python setup.py install | ❌ |
+| pkg_resources | python2.7 | python setup.py develop | python setup.py develop | ✅ |
+| pkg_resources | python3.7 | pip install . | pip install . | ✅ |
+| pkg_resources | python3.7 | pip install . | pip install -e . | ✅ |
+| pkg_resources | python3.7 | pip install . | python setup.py install | ❌ |
+| pkg_resources | python3.7 | pip install . | python setup.py develop | ✅ |
+| pkg_resources | python3.7 | pip install -e . | pip install . | ✅ |
+| pkg_resources | python3.7 | pip install -e . | pip install -e . | ✅ |
+| pkg_resources | python3.7 | pip install -e . | python setup.py install | ❌ |
+| pkg_resources | python3.7 | pip install -e . | python setup.py develop | ✅ |
+| pkg_resources | python3.7 | python setup.py install | pip install . | ❌ |
+| pkg_resources | python3.7 | python setup.py install | pip install -e . | ❌ |
+| pkg_resources | python3.7 | python setup.py install | python setup.py install | ✅ |
+| pkg_resources | python3.7 | python setup.py install | python setup.py develop | ❌ |
+| pkg_resources | python3.7 | python setup.py develop | pip install . | ✅ |
+| pkg_resources | python3.7 | python setup.py develop | pip install -e . | ✅ |
+| pkg_resources | python3.7 | python setup.py develop | python setup.py install | ❌ |
+| pkg_resources | python3.7 | python setup.py develop | python setup.py develop | ✅ |
+| pep420 | python2.7 | pip install . | pip install . | ❌ |
+| pep420 | python2.7 | pip install . | pip install -e . | ❌ |
+| pep420 | python2.7 | pip install . | python setup.py install | ❌ |
+| pep420 | python2.7 | pip install . | python setup.py develop | ❌ |
+| pep420 | python2.7 | pip install -e . | pip install . | ❌ |
+| pep420 | python2.7 | pip install -e . | pip install -e . | ❌ |
+| pep420 | python2.7 | pip install -e . | python setup.py install | ❌ |
+| pep420 | python2.7 | pip install -e . | python setup.py develop | ❌ |
+| pep420 | python2.7 | python setup.py install | pip install . | ❌ |
+| pep420 | python2.7 | python setup.py install | pip install -e . | ❌ |
+| pep420 | python2.7 | python setup.py install | python setup.py install | ❌ |
+| pep420 | python2.7 | python setup.py install | python setup.py develop | ❌ |
+| pep420 | python2.7 | python setup.py develop | pip install . | ❌ |
+| pep420 | python2.7 | python setup.py develop | pip install -e . | ❌ |
+| pep420 | python2.7 | python setup.py develop | python setup.py install | ❌ |
+| pep420 | python2.7 | python setup.py develop | python setup.py develop | ❌ |
+| pep420 | python3.7 | pip install . | pip install . | ✅ |
+| pep420 | python3.7 | pip install . | pip install -e . | ✅ |
+| pep420 | python3.7 | pip install . | python setup.py install | ✅ |
+| pep420 | python3.7 | pip install . | python setup.py develop | ✅ |
+| pep420 | python3.7 | pip install -e . | pip install . | ✅ |
+| pep420 | python3.7 | pip install -e . | pip install -e . | ✅ |
+| pep420 | python3.7 | pip install -e . | python setup.py install | ✅ |
+| pep420 | python3.7 | pip install -e . | python setup.py develop | ✅ |
+| pep420 | python3.7 | python setup.py install | pip install . | ✅ |
+| pep420 | python3.7 | python setup.py install | pip install -e . | ✅ |
+| pep420 | python3.7 | python setup.py install | python setup.py install | ✅ |
+| pep420 | python3.7 | python setup.py install | python setup.py develop | ✅ |
+| pep420 | python3.7 | python setup.py develop | pip install . | ✅ |
+| pep420 | python3.7 | python setup.py develop | pip install -e . | ✅ |
+| pep420 | python3.7 | python setup.py develop | python setup.py install | ✅ |
+| pep420 | python3.7 | python setup.py develop | python setup.py develop | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install . | pip install . | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install . | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install . | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install . | python setup.py develop | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install -e . | pip install . | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install -e . | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install -e . | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | pip install -e . | python setup.py develop | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py install | pip install . | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py install | pip install -e . | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py install | python setup.py install | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py install | python setup.py develop | ✅ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py develop | pip install . | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py develop | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py develop | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python2.7 | python setup.py develop | python setup.py develop | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install . | pip install . | ✅ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install . | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install . | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install . | python setup.py develop | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install -e . | pip install . | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install -e . | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install -e . | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | pip install -e . | python setup.py develop | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py install | pip install . | ✅ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py install | pip install -e . | ✅ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py install | python setup.py install | ✅ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py install | python setup.py develop | ✅ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py develop | pip install . | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py develop | pip install -e . | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py develop | python setup.py install | ❌ |
+| cross_pkg_resources_pkgutil | python3.7 | python setup.py develop | python setup.py develop | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install . | pip install . | ✅ |
+| cross_pep420_pkgutil | python2.7 | pip install . | pip install -e . | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install . | python setup.py install | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install . | python setup.py develop | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install -e . | pip install . | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install -e . | pip install -e . | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install -e . | python setup.py install | ❌ |
+| cross_pep420_pkgutil | python2.7 | pip install -e . | python setup.py develop | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py install | pip install . | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py install | pip install -e . | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py install | python setup.py install | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py install | python setup.py develop | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py develop | pip install . | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py develop | pip install -e . | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py develop | python setup.py install | ❌ |
+| cross_pep420_pkgutil | python2.7 | python setup.py develop | python setup.py develop | ❌ |
+| cross_pep420_pkgutil | python3.7 | pip install . | pip install . | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install . | pip install -e . | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install . | python setup.py install | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install . | python setup.py develop | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install -e . | pip install . | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install -e . | pip install -e . | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install -e . | python setup.py install | ✅ |
+| cross_pep420_pkgutil | python3.7 | pip install -e . | python setup.py develop | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py install | pip install . | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py install | pip install -e . | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py install | python setup.py install | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py install | python setup.py develop | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py develop | pip install . | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py develop | pip install -e . | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py develop | python setup.py install | ✅ |
+| cross_pep420_pkgutil | python3.7 | python setup.py develop | python setup.py develop | ✅ |


### PR DESCRIPTION
Use newer nox-2018.10.17 and provide the necessary adaptations to it.

NOTES: 
* Older nox-automation does not seem to work out of the box any more.
  `nox` is missing or collides with local `nox.py`, etc.
* `table.md` header with tool versions is not generated automatically !?!
* ADD: `requirements.txt` file to simplify installation of python dependencies with `pip`.
* Table output from `table.json` or execution order seems to differ; is not sorted any more by session name
