### PR TITLE
Add a GitHub Action to run nox and pytest on current Python

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -1,0 +1,22 @@
+name: nox
+on: [push, pull_request]
+jobs:
+  nox:
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.8', '3.10', '3.12']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python3 --version && python --version
+      - run: pip install --upgrade pip setuptools
+      - run: pip install nox pytest virtualenv
+      - run: pytest . || true  # See pytest's warnings
+      - run: nox --python ${{ matrix.python }}
+      # - run: nox --python ${{ matrix.python }} --report report.json && python report_to_table.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # -- REQUIRES: nox >= 2018.10.17
 # SEE: https://nox.readthedocs.io/en/stable/index.html
-USE_PYTHON_VERSIONS_DEFAULT = ["2.7", "3.7"]
+USE_PYTHON_VERSIONS_DEFAULT = ["3.8", "3.10", "3.12"]
 USE_PYTHON_VERSIONS = os.environ.get("NOXFILE_PYTHON_VERSIONS", "").split()
 if not USE_PYTHON_VERSIONS:
     USE_PYTHON_VERSIONS = USE_PYTHON_VERSIONS_DEFAULT


### PR DESCRIPTION
Run `nox` on every pull request on Python v3.8, v3.10, and v3.12.
* Legacy Python died 1,372 days ago on 1/1/2020 so  GitHub Actions no longer supports running it.

Test results: https://github.com/cclauss/sample-namespace-packages/actions